### PR TITLE
Add Jil to JsonSerializersBenchmark

### DIFF
--- a/examples/JsonSerializersBenchmark/JsonSerializersBenchmark.csproj
+++ b/examples/JsonSerializersBenchmark/JsonSerializersBenchmark.csproj
@@ -43,8 +43,9 @@
     <Reference Include="Jayrock.Json">
       <HintPath>..\..\packages\jayrock-json.0.9.16530\lib\net40\Jayrock.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Jil">
-      <HintPath>..\..\packages\Jil.1.0.0\lib\net45\Jil.dll</HintPath>
+    <Reference Include="Jil, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Jil.1.0.1\lib\net45\Jil.dll</HintPath>
     </Reference>
     <Reference Include="JsonFx">
       <HintPath>..\..\packages\JsonFx.2.0.1209.2802\lib\net40\JsonFx.dll</HintPath>

--- a/examples/JsonSerializersBenchmark/JsonSerializersBenchmark.csproj
+++ b/examples/JsonSerializersBenchmark/JsonSerializersBenchmark.csproj
@@ -43,6 +43,9 @@
     <Reference Include="Jayrock.Json">
       <HintPath>..\..\packages\jayrock-json.0.9.16530\lib\net40\Jayrock.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Jil">
+      <HintPath>..\..\packages\Jil.1.0.0\lib\net45\Jil.dll</HintPath>
+    </Reference>
     <Reference Include="JsonFx">
       <HintPath>..\..\packages\JsonFx.2.0.1209.2802\lib\net40\JsonFx.dll</HintPath>
     </Reference>
@@ -61,6 +64,9 @@
     <Reference Include="ServiceStack.Text, Version=4.0.8.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\ServiceStack.Text.4.0.8\lib\net40\ServiceStack.Text.dll</HintPath>
+    </Reference>
+    <Reference Include="Sigil">
+      <HintPath>..\..\packages\Sigil.4.0.2\lib\net45\Sigil.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/examples/JsonSerializersBenchmark/JsonSerializersSpeedTest.cs
+++ b/examples/JsonSerializersBenchmark/JsonSerializersSpeedTest.cs
@@ -101,6 +101,10 @@ namespace SimlpeSpeedTester.Example
             //    "XamlServices",
             //    DoSpeedTest("XamlServices", SerializeWithXamlServices, DeserializeWithXamlServices<SimpleObject>, CountAverageJsonStringPayload));
 
+            results.Add(
+                "Jil",
+                DoSpeedTest("Jil", SerializeWithJil, DeserializeWithJil, CountAverageJsonStringPayload));
+
             return results;
         }
 
@@ -424,6 +428,22 @@ namespace SimlpeSpeedTester.Example
         #endregion
 
         #region System.Json
+
+        private static List<string> SerializeWithJil(List<SimpleObject> objects)
+        {
+            return objects.Select(o =>
+            {
+                return Jil.JSON.Serialize(o);
+            }).ToList();
+        }
+
+        private static List<SimpleObject> DeserializeWithJil(List<string> arg)
+        {
+            return arg.Select(j =>
+            {
+                return Jil.JSON.Deserialize<SimpleObject>(j);
+            }).ToList();
+        }
 
         private static List<string> SerializeWithSystemJson(List<SimpleObject> objects)
         {

--- a/examples/JsonSerializersBenchmark/packages.config
+++ b/examples/JsonSerializersBenchmark/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="fastJSON" version="2.0.27.1" targetFramework="net45" />
   <package id="jayrock-json" version="0.9.16530" targetFramework="net45" />
-  <package id="Jil" version="1.0.0" targetFramework="net45" />
+  <package id="Jil" version="1.0.1" targetFramework="net45" />
   <package id="JsonFx" version="2.0.1209.2802" targetFramework="net45" />
   <package id="mongocsharpdriver" version="1.8.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />

--- a/examples/JsonSerializersBenchmark/packages.config
+++ b/examples/JsonSerializersBenchmark/packages.config
@@ -2,10 +2,12 @@
 <packages>
   <package id="fastJSON" version="2.0.27.1" targetFramework="net45" />
   <package id="jayrock-json" version="0.9.16530" targetFramework="net45" />
+  <package id="Jil" version="1.0.0" targetFramework="net45" />
   <package id="JsonFx" version="2.0.1209.2802" targetFramework="net45" />
   <package id="mongocsharpdriver" version="1.8.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="ServiceStack.Text" version="4.0.8" targetFramework="net45" />
+  <package id="Sigil" version="4.0.2" targetFramework="net45" />
   <package id="System.Json" version="4.0.20126.16343" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Adds a dependency on Sigil 4.0.2 (https://github.com/kevin-montrose/Sigil) and Jil 1.0.1 (https://github.com/kevin-montrose/Jil); both are available in Nuget.

Jil is quite fast on my machine, but not as fast as protobuf-net.
