### PR TITLE
Core CLR conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,8 @@ ClientBin
 [Ss]tyle[Cc]op.*
 ~$*
 *.dbmdl
+.vs/
+project.lock.json
 Generated_Code #added for RIA/Silverlight projects
 
 # Backup & report files from converting an old project file to a newer

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,7 +3,9 @@
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
+    <!--
     <add key="CoreCLR" value="https://www.myget.org/F/dotnet-coreclr/api/v3/index.json" />
+    -->
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="CoreCLR" value="https://www.myget.org/F/dotnet-coreclr/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/SimpleSpeedTester.DNX.sln
+++ b/SimpleSpeedTester.DNX.sln
@@ -1,0 +1,115 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.24606.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{E8ED0C5C-C3B1-4A75-B4F6-7933657B347F}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\NuGet.Config = .nuget\NuGet.Config
+		.nuget\NuGet.exe = .nuget\NuGet.exe
+		.nuget\NuGet.targets = .nuget\NuGet.targets
+		.nuget\packages.config = .nuget\packages.config
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "project", "project", "{7A66622C-5F9A-45FE-A81E-8519DAC031FD}"
+	ProjectSection(SolutionItems) = preProject
+		build.fsx = build.fsx
+		global.json = global.json
+		NuGet.Config = NuGet.Config
+		RELEASE_NOTES.md = RELEASE_NOTES.md
+		RunBenchmarks.fsx = RunBenchmarks.fsx
+		nuget\SimpleSpeedTester.nuspec = nuget\SimpleSpeedTester.nuspec
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{2ECDAF10-D790-4136-BB0E-A1DBD995D5A8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{F891B8A3-232F-4736-9CF7-1C1D2BDCB6F8}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "TestRecord", "examples\TestRecord\TestRecord.fsproj", "{088C6FFB-7156-4172-96D8-32111C602067}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "SimpleSpeedTester", "src\SimpleSpeedTester\SimpleSpeedTester.xproj", "{83317A4D-5502-44D2-942D-F83D7B17F539}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "SimpleSpeedTester.Tests", "tests\SimpleSpeedTester.Tests\SimpleSpeedTester.Tests.xproj", "{9C3A9BCA-D67B-49AB-92B8-F3CA56C20418}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "CollectionBenchmark", "examples\CollectionBenchmark\CollectionBenchmark.xproj", "{76798EF2-5814-43E8-9E6A-182B5C0473CC}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "SimpleSpeedTester.Example", "examples\SimpleSpeedTester.Example\SimpleSpeedTester.Example.xproj", "{1DD7CC9E-1E5A-4860-B746-60BB31E52520}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|Mixed Platforms = Debug|Mixed Platforms
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|Mixed Platforms = Release|Mixed Platforms
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{088C6FFB-7156-4172-96D8-32111C602067}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{088C6FFB-7156-4172-96D8-32111C602067}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{088C6FFB-7156-4172-96D8-32111C602067}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{088C6FFB-7156-4172-96D8-32111C602067}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{088C6FFB-7156-4172-96D8-32111C602067}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{088C6FFB-7156-4172-96D8-32111C602067}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{088C6FFB-7156-4172-96D8-32111C602067}.Release|Any CPU.Build.0 = Release|Any CPU
+		{088C6FFB-7156-4172-96D8-32111C602067}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{088C6FFB-7156-4172-96D8-32111C602067}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{088C6FFB-7156-4172-96D8-32111C602067}.Release|x86.ActiveCfg = Release|Any CPU
+		{83317A4D-5502-44D2-942D-F83D7B17F539}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{83317A4D-5502-44D2-942D-F83D7B17F539}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{83317A4D-5502-44D2-942D-F83D7B17F539}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{83317A4D-5502-44D2-942D-F83D7B17F539}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{83317A4D-5502-44D2-942D-F83D7B17F539}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{83317A4D-5502-44D2-942D-F83D7B17F539}.Debug|x86.Build.0 = Debug|Any CPU
+		{83317A4D-5502-44D2-942D-F83D7B17F539}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{83317A4D-5502-44D2-942D-F83D7B17F539}.Release|Any CPU.Build.0 = Release|Any CPU
+		{83317A4D-5502-44D2-942D-F83D7B17F539}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{83317A4D-5502-44D2-942D-F83D7B17F539}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{83317A4D-5502-44D2-942D-F83D7B17F539}.Release|x86.ActiveCfg = Release|Any CPU
+		{83317A4D-5502-44D2-942D-F83D7B17F539}.Release|x86.Build.0 = Release|Any CPU
+		{9C3A9BCA-D67B-49AB-92B8-F3CA56C20418}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C3A9BCA-D67B-49AB-92B8-F3CA56C20418}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C3A9BCA-D67B-49AB-92B8-F3CA56C20418}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{9C3A9BCA-D67B-49AB-92B8-F3CA56C20418}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{9C3A9BCA-D67B-49AB-92B8-F3CA56C20418}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9C3A9BCA-D67B-49AB-92B8-F3CA56C20418}.Debug|x86.Build.0 = Debug|Any CPU
+		{9C3A9BCA-D67B-49AB-92B8-F3CA56C20418}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C3A9BCA-D67B-49AB-92B8-F3CA56C20418}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C3A9BCA-D67B-49AB-92B8-F3CA56C20418}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{9C3A9BCA-D67B-49AB-92B8-F3CA56C20418}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{9C3A9BCA-D67B-49AB-92B8-F3CA56C20418}.Release|x86.ActiveCfg = Release|Any CPU
+		{9C3A9BCA-D67B-49AB-92B8-F3CA56C20418}.Release|x86.Build.0 = Release|Any CPU
+		{76798EF2-5814-43E8-9E6A-182B5C0473CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{76798EF2-5814-43E8-9E6A-182B5C0473CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{76798EF2-5814-43E8-9E6A-182B5C0473CC}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{76798EF2-5814-43E8-9E6A-182B5C0473CC}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{76798EF2-5814-43E8-9E6A-182B5C0473CC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{76798EF2-5814-43E8-9E6A-182B5C0473CC}.Debug|x86.Build.0 = Debug|Any CPU
+		{76798EF2-5814-43E8-9E6A-182B5C0473CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{76798EF2-5814-43E8-9E6A-182B5C0473CC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{76798EF2-5814-43E8-9E6A-182B5C0473CC}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{76798EF2-5814-43E8-9E6A-182B5C0473CC}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{76798EF2-5814-43E8-9E6A-182B5C0473CC}.Release|x86.ActiveCfg = Release|Any CPU
+		{76798EF2-5814-43E8-9E6A-182B5C0473CC}.Release|x86.Build.0 = Release|Any CPU
+		{1DD7CC9E-1E5A-4860-B746-60BB31E52520}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1DD7CC9E-1E5A-4860-B746-60BB31E52520}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1DD7CC9E-1E5A-4860-B746-60BB31E52520}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{1DD7CC9E-1E5A-4860-B746-60BB31E52520}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{1DD7CC9E-1E5A-4860-B746-60BB31E52520}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1DD7CC9E-1E5A-4860-B746-60BB31E52520}.Debug|x86.Build.0 = Debug|Any CPU
+		{1DD7CC9E-1E5A-4860-B746-60BB31E52520}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1DD7CC9E-1E5A-4860-B746-60BB31E52520}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1DD7CC9E-1E5A-4860-B746-60BB31E52520}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{1DD7CC9E-1E5A-4860-B746-60BB31E52520}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{1DD7CC9E-1E5A-4860-B746-60BB31E52520}.Release|x86.ActiveCfg = Release|Any CPU
+		{1DD7CC9E-1E5A-4860-B746-60BB31E52520}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{9C3A9BCA-D67B-49AB-92B8-F3CA56C20418} = {2ECDAF10-D790-4136-BB0E-A1DBD995D5A8}
+		{76798EF2-5814-43E8-9E6A-182B5C0473CC} = {F891B8A3-232F-4736-9CF7-1C1D2BDCB6F8}
+		{1DD7CC9E-1E5A-4860-B746-60BB31E52520} = {F891B8A3-232F-4736-9CF7-1C1D2BDCB6F8}
+	EndGlobalSection
+EndGlobal

--- a/SimpleSpeedTester.DNX.sln
+++ b/SimpleSpeedTester.DNX.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24606.1
+VisualStudioVersion = 14.0.24709.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{E8ED0C5C-C3B1-4A75-B4F6-7933657B347F}"
 	ProjectSection(SolutionItems) = preProject
@@ -34,6 +34,11 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "CollectionBenchmark", "examples\CollectionBenchmark\CollectionBenchmark.xproj", "{76798EF2-5814-43E8-9E6A-182B5C0473CC}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "SimpleSpeedTester.Example", "examples\SimpleSpeedTester.Example\SimpleSpeedTester.Example.xproj", "{1DD7CC9E-1E5A-4860-B746-60BB31E52520}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{79800A3A-60DB-41BF-B6EA-1424CDE39F13}"
+	ProjectSection(SolutionItems) = preProject
+		NuGet.Config = NuGet.Config
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/examples/CollectionBenchmark/CollectionBenchmark.xproj
+++ b/examples/CollectionBenchmark/CollectionBenchmark.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>76798ef2-5814-43e8-9e6a-182b5c0473cc</ProjectGuid>
+    <RootNamespace>CollectionBenchmark</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/examples/CollectionBenchmark/CollectionSpeedTest.cs
+++ b/examples/CollectionBenchmark/CollectionSpeedTest.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 
+using System.Linq;
+#if !NOIMMUTABLE
+using System.Collections.Immutable;
+#endif
+#if !NOFSHARP
 using Microsoft.FSharp.Collections;
+#endif
 
 using SimpleSpeedTester.Core;
 using SimpleSpeedTester.Interfaces;
@@ -25,11 +29,15 @@ namespace SimpleSpeedTester.Example
             results.Add("List<T> with value type", AddItemsWithListT("List<T> with value type", 42));
             results.Add("List<T> with ref type", AddItemsWithListT("List<T> with ref type", "42"));
 
+#if !NOIMMUTABLE
             results.Add("ImmutableList<T> with value type", AddItemsWithImmutableListT("ImmutableList<T> with value type", 42));
             results.Add("ImmutableList<T> with ref type", AddItemsWithImmutableListT("ImmutableList<T> with ref type", "42"));
+#endif
 
+#if !NOFSHARP
             results.Add("FSharpList<T> with value type", AddItemsWithFSharpListT("FSharpList<T> with value type", 42));
             results.Add("FSharpList<T> with ref type", AddItemsWithFSharpListT("FSharpList<T> with ref type", "42"));
+#endif
 
             return results;
         }
@@ -59,6 +67,7 @@ namespace SimpleSpeedTester.Example
             return Tuple.Create(addResultSummary, removeResultSummary);
         }
 
+#if !NOIMMUTABLE
         private static Tuple<ITestResultSummary, ITestResultSummary> AddItemsWithImmutableListT<T>(string testGroupName, T item)
         {
             var list = ImmutableList<T>.Empty;
@@ -83,6 +92,9 @@ namespace SimpleSpeedTester.Example
             
             return Tuple.Create(addResultSummary, removeResultSummary);
         }
+#endif
+
+#if !NOFSHARP
 
         private static Tuple<ITestResultSummary, ITestResultSummary> AddItemsWithFSharpListT<T>(string testGroupName, T item)
         {
@@ -108,5 +120,6 @@ namespace SimpleSpeedTester.Example
             
             return Tuple.Create(addResultSummary, removeResultSummary);
         }
+#endif
     }
 }

--- a/examples/CollectionBenchmark/Properties/AssemblyInfo.cs
+++ b/examples/CollectionBenchmark/Properties/AssemblyInfo.cs
@@ -19,8 +19,10 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
+#if !COREFX
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("3f3e2c92-83d9-493c-8035-2919df0d061c")]
+#endif
 
 // Version information for an assembly consists of the following four values:
 //

--- a/examples/CollectionBenchmark/project.json
+++ b/examples/CollectionBenchmark/project.json
@@ -1,0 +1,32 @@
+﻿{
+  "version": "1.0",
+  "compilationOptions": { "define": [ "COREFX" ] },
+  "dependencies": {
+    "SimpleSpeedTester": {
+      "target": "project",
+      "version": "1.1.1"
+    }
+  },
+  "frameworks": {
+    "dnx451": {
+      "compilationOptions": { "define": [ "NOFSHARP" ] },
+      "frameworkAssemblies": {
+        "System.Runtime": "4.0.10.0"
+      },
+      "dependencies": {
+        "System.Collections.Immutable": "1.1.37"
+      }
+    },
+    "dnxcore50": {
+      "compilationOptions": { "define": [ "NOFSHARP", "NOIMMUTABLE" ] },
+      "dependencies": {
+        "System.Runtime": "4.0.21-beta-23409",
+        "System.Runtime.Extensions": "4.0.11-beta-23409",
+        "System.Collections": "4.0.11-beta-23409",
+        "System.Collections.Concurrent": "4.0.11-beta-23409",
+        "System.Console": "4.0.0-beta-23225",
+        "System.Linq": "4.0.1-beta-23409"
+      }
+    }
+  }
+}

--- a/examples/CollectionBenchmark/project.json
+++ b/examples/CollectionBenchmark/project.json
@@ -14,18 +14,18 @@
         "System.Runtime": "4.0.10.0"
       },
       "dependencies": {
-        "System.Collections.Immutable":"1.1.36"
+        "System.Collections.Immutable": "1.1.36"
       }
     },
-    "dnxcore50": {
+    "dotnet5.4": {
       "compilationOptions": { "define": [ "NOFSHARP", "NOIMMUTABLE" ] },
       "dependencies": {
-        "System.Runtime": "4.0.21-beta-23409",
-        "System.Runtime.Extensions": "4.0.11-beta-23409",
-        "System.Collections": "4.0.11-beta-23409",
-        "System.Collections.Concurrent": "4.0.11-beta-23409",
-        "System.Console": "4.0.0-beta-23225",
-        "System.Linq": "4.0.1-beta-23409"
+        "System.Runtime": "4.0.21-beta-23516",
+        "System.Runtime.Extensions": "4.0.11-beta-23516",
+        "System.Collections": "4.0.11-beta-23516",
+        "System.Collections.Concurrent": "4.0.11-beta-23516",
+        "System.Console": "4.0.0-beta-23516",
+        "System.Linq": "4.0.1-beta-23516"
       }
     }
   }

--- a/examples/CollectionBenchmark/project.json
+++ b/examples/CollectionBenchmark/project.json
@@ -20,12 +20,12 @@
     "dotnet5.4": {
       "compilationOptions": { "define": [ "NOFSHARP", "NOIMMUTABLE" ] },
       "dependencies": {
-        "System.Runtime": "4.0.21-beta-23516",
-        "System.Runtime.Extensions": "4.0.11-beta-23516",
-        "System.Collections": "4.0.11-beta-23516",
-        "System.Collections.Concurrent": "4.0.11-beta-23516",
-        "System.Console": "4.0.0-beta-23516",
-        "System.Linq": "4.0.1-beta-23516"
+        "System.Runtime": "4.0.21-*",
+        "System.Runtime.Extensions": "4.0.11-*",
+        "System.Collections": "4.0.11-*",
+        "System.Collections.Concurrent": "4.0.11-*",
+        "System.Console": "4.0.0-*",
+        "System.Linq": "4.0.1-*"
       }
     }
   }

--- a/examples/CollectionBenchmark/project.json
+++ b/examples/CollectionBenchmark/project.json
@@ -14,7 +14,7 @@
         "System.Runtime": "4.0.10.0"
       },
       "dependencies": {
-        "System.Collections.Immutable": "1.1.37"
+        "System.Collections.Immutable":"1.1.36"
       }
     },
     "dnxcore50": {

--- a/examples/JsonSerializersBenchmark/JsonSerializersBenchmark.xproj
+++ b/examples/JsonSerializersBenchmark/JsonSerializersBenchmark.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>26711e9c-4cc1-4c17-bfd1-8653cd89a1bb</ProjectGuid>
+    <RootNamespace>JsonSerializersBenchmark</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/examples/SimpleSpeedTester.Example/Program.cs
+++ b/examples/SimpleSpeedTester.Example/Program.cs
@@ -20,7 +20,11 @@ namespace SimpleSpeedTester.Example
             Example4();
 
             Console.WriteLine("all done...");
+#if COREFX
+            Console.ReadLine();
+#else
             Console.ReadKey();
+#endif
         }
 
         private static void Example1()

--- a/examples/SimpleSpeedTester.Example/Properties/AssemblyInfo.cs
+++ b/examples/SimpleSpeedTester.Example/Properties/AssemblyInfo.cs
@@ -19,8 +19,10 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
+#if !COREFX
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("f60ae133-0214-4655-a794-f08fa59aed16")]
+#endif
 
 // Version information for an assembly consists of the following four values:
 //

--- a/examples/SimpleSpeedTester.Example/SimpleSpeedTester.Example.xproj
+++ b/examples/SimpleSpeedTester.Example/SimpleSpeedTester.Example.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>1dd7cc9e-1e5a-4860-b746-60bb31e52520</ProjectGuid>
+    <RootNamespace>SimpleSpeedTester.Example</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/examples/SimpleSpeedTester.Example/project.json
+++ b/examples/SimpleSpeedTester.Example/project.json
@@ -1,0 +1,33 @@
+﻿{
+  "commands": {
+    "run": "SimpleSpeedTester.Example"
+  },
+  "version": "1.0",
+  "compilationOptions": { "define": [ "COREFX" ] },
+  "dependencies": {
+    "SimpleSpeedTester": {
+      "target": "project",
+      "version": "1.1.1"
+    }
+  },
+  "frameworks": {
+    "dnx451": {
+      "frameworkAssemblies": {
+        "System.Runtime": "4.0.10.0"
+      },
+      "dependencies": {
+      }
+    },
+    "dnxcore50": {
+      "dependencies": {
+        "System.Runtime": "4.0.21-beta-23409",
+        "System.Runtime.Extensions": "4.0.11-beta-23409",
+        "System.Collections": "4.0.11-beta-23409",
+        "System.Collections.Concurrent": "4.0.11-beta-23409",
+        "System.Console": "4.0.0-beta-23225",
+        "System.Linq": "4.0.1-beta-23409",
+        "System.Threading.Thread": "4.0.0-beta-23409"
+      }
+    }
+  }
+}

--- a/examples/SimpleSpeedTester.Example/project.json
+++ b/examples/SimpleSpeedTester.Example/project.json
@@ -20,13 +20,13 @@
     },
     "dotnet5.4": {
       "dependencies": {
-        "System.Runtime": "4.0.21-beta-23516",
-        "System.Runtime.Extensions": "4.0.11-beta-23516",
-        "System.Collections": "4.0.11-beta-23516",
-        "System.Collections.Concurrent": "4.0.11-beta-23516",
-        "System.Console": "4.0.0-beta-23516",
-        "System.Linq": "4.0.1-beta-23516",
-        "System.Threading.Thread": "4.0.0-beta-23516"
+        "System.Runtime": "4.0.21-*",
+        "System.Runtime.Extensions": "4.0.11-*",
+        "System.Collections": "4.0.11-*",
+        "System.Collections.Concurrent": "4.0.11-*",
+        "System.Console": "4.0.0-*",
+        "System.Linq": "4.0.1-*",
+        "System.Threading.Thread": "4.0.0-*"
       }
     }
   }

--- a/examples/SimpleSpeedTester.Example/project.json
+++ b/examples/SimpleSpeedTester.Example/project.json
@@ -18,15 +18,15 @@
       "dependencies": {
       }
     },
-    "dnxcore50": {
+    "dotnet5.4": {
       "dependencies": {
-        "System.Runtime": "4.0.21-beta-23409",
-        "System.Runtime.Extensions": "4.0.11-beta-23409",
-        "System.Collections": "4.0.11-beta-23409",
-        "System.Collections.Concurrent": "4.0.11-beta-23409",
-        "System.Console": "4.0.0-beta-23225",
-        "System.Linq": "4.0.1-beta-23409",
-        "System.Threading.Thread": "4.0.0-beta-23409"
+        "System.Runtime": "4.0.21-beta-23516",
+        "System.Runtime.Extensions": "4.0.11-beta-23516",
+        "System.Collections": "4.0.11-beta-23516",
+        "System.Collections.Concurrent": "4.0.11-beta-23516",
+        "System.Console": "4.0.0-beta-23516",
+        "System.Linq": "4.0.1-beta-23516",
+        "System.Threading.Thread": "4.0.0-beta-23516"
       }
     }
   }

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+﻿{
+  "projects": ["src/SimpleSpeedTester","tests/SimpleSpeedTester.Tests"],
+  "sdk": {
+    "version": "1.0.0-beta8"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "projects": ["src/SimpleSpeedTester","tests/SimpleSpeedTester.Tests"],
   "sdk": {
-    "version": "1.0.0-beta8"
+    "version": "1.0.0-rc1-final"
   }
 }

--- a/src/SimpleSpeedTester/SimpleSpeedTester.xproj
+++ b/src/SimpleSpeedTester/SimpleSpeedTester.xproj
@@ -17,5 +17,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
+  </PropertyGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/SimpleSpeedTester/SimpleSpeedTester.xproj
+++ b/src/SimpleSpeedTester/SimpleSpeedTester.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>83317a4d-5502-44d2-942d-f83d7b17f539</ProjectGuid>
+    <RootNamespace>SimpleSpeedTester</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/SimpleSpeedTester/project.json
+++ b/src/SimpleSpeedTester/project.json
@@ -16,14 +16,14 @@
     },
     "net40": {
     },
-    "dnxcore50": {
+    "dotnet5.4": {
       "compilationOptions": { "define": [ "COREFX" ] },
       "dependencies": {
-        "System.Runtime": "4.0.21-beta-23409",
-        "System.Runtime.Extensions": "4.0.11-beta-23409",
-        "System.Collections": "4.0.11-beta-23409",
-        "System.Collections.Concurrent": "4.0.11-beta-23409",
-        "System.Linq": "4.0.1-beta-23409"
+        "System.Runtime": "4.0.21-beta-23516",
+        "System.Runtime.Extensions": "4.0.11-beta-23516",
+        "System.Collections": "4.0.11-beta-23516",
+        "System.Collections.Concurrent":"4.0.11-beta-23516",
+        "System.Linq": "4.0.1-beta-23516"
       }
     }
   }

--- a/src/SimpleSpeedTester/project.json
+++ b/src/SimpleSpeedTester/project.json
@@ -25,6 +25,16 @@
         "System.Collections.Concurrent": "4.0.11-*",
         "System.Linq": "4.0.1-*"
       }
+    },
+    "dotnet5.4": {
+      "compilationOptions": { "define": [ "COREFX" ] },
+      "dependencies": {
+        "System.Runtime": "4.0.21-*",
+        "System.Runtime.Extensions": "4.0.11-*",
+        "System.Collections": "4.0.11-*",
+        "System.Collections.Concurrent": "4.0.11-*",
+        "System.Linq": "4.0.1-*"
+      }
     }
   }
 }

--- a/src/SimpleSpeedTester/project.json
+++ b/src/SimpleSpeedTester/project.json
@@ -1,0 +1,30 @@
+﻿{
+  "version": "1.1.1",
+  "summary": "A simple framework to help benchmark test your .Net code.",
+  "description": "SimpleSpeedTester is a simple, easy to use framework that helps you speed test your .Net code by taking care some of the orchestration for you.\n\nIt should NOT be confused with a performance profiler such as JetBrains' dotTrace or RedGate's ANTS profiler.\n\nThe SimpleSpeedTester is intended for one thing and one thing only – help you speed test a specific piece of code/method over multiple runs, collate the results and work out the average for you so you only have to focus on producing the code you want to test.\n\nWhere it might be useful is when you want to compare the performance of two similar components/methods in terms of speed, for instance, the serialization and deserialization speed of DataContractJsonSerializer vs JavaScriptSerializer.",
+  "authors": [ "Yan Cui" ],
+  "owners": [ "theburningmonk" ],
+  "tags": [ "C#","csharp","testing","benchmark","performance" ],
+  "releaseNotes": "Support for core-clr",
+  "iconUrl": "https://raw.github.com/theburningmonk/SimpleSpeedTester/master/nuget/sst-logo.png",
+  "requireLicenseAcceptance": false,
+  "projectUrl": "https://github.com/theburningmonk/SimpleSpeedTester",
+  "licenseUrl": "https://github.com/theburningmonk/SimpleSpeedTester/blob/master/LICENSE",
+  "copyright": "Copyright 2013",
+  "frameworks": {
+    "dnx451": {
+    },
+    "net40": {
+    },
+    "dnxcore50": {
+      "compilationOptions": { "define": [ "COREFX" ] },
+      "dependencies": {
+        "System.Runtime": "4.0.21-beta-23409",
+        "System.Runtime.Extensions": "4.0.11-beta-23409",
+        "System.Collections": "4.0.11-beta-23409",
+        "System.Collections.Concurrent": "4.0.11-beta-23409",
+        "System.Linq": "4.0.1-beta-23409"
+      }
+    }
+  }
+}

--- a/src/SimpleSpeedTester/project.json
+++ b/src/SimpleSpeedTester/project.json
@@ -16,14 +16,14 @@
     },
     "net40": {
     },
-    "dotnet5.4": {
+    "dotnet5.2": {
       "compilationOptions": { "define": [ "COREFX" ] },
       "dependencies": {
-        "System.Runtime": "4.0.21-beta-23516",
-        "System.Runtime.Extensions": "4.0.11-beta-23516",
-        "System.Collections": "4.0.11-beta-23516",
-        "System.Collections.Concurrent":"4.0.11-beta-23516",
-        "System.Linq": "4.0.1-beta-23516"
+        "System.Runtime": "4.0.21-*",
+        "System.Runtime.Extensions": "4.0.11-*",
+        "System.Collections": "4.0.11-*",
+        "System.Collections.Concurrent": "4.0.11-*",
+        "System.Linq": "4.0.1-*"
       }
     }
   }

--- a/tests/SimpleSpeedTester.Tests/SimpleSpeedTester.Tests.xproj
+++ b/tests/SimpleSpeedTester.Tests/SimpleSpeedTester.Tests.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>9c3a9bca-d67b-49ab-92b8-f3ca56c20418</ProjectGuid>
+    <RootNamespace>SimpleSpeedTester.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/tests/SimpleSpeedTester.Tests/TestActionTest.cs
+++ b/tests/SimpleSpeedTester.Tests/TestActionTest.cs
@@ -11,38 +11,72 @@ namespace SimpleSpeedTester.Tests
         [ExpectedException(typeof(ArgumentException))]
         public void TestNullActionName()
         {
-            new Test(null, DoNothingAction, 1, GetTestGroup());
+#if XUNIT
+            Xunit.Assert.Throws<ArgumentException>(() =>
+            {
+#endif
+                new Test(null, DoNothingAction, 1, GetTestGroup());
+#if XUNIT
+            });
+#endif
         }
 
         [Test]
         [ExpectedException(typeof(ArgumentException))]
         public void TestEmptyActionName()
         {
-            new Test(string.Empty, DoNothingAction, 1, GetTestGroup());
+#if XUNIT
+            Xunit.Assert.Throws<ArgumentException>(() =>
+            {
+#endif
+                new Test(string.Empty, DoNothingAction, 1, GetTestGroup());
+#if XUNIT
+            });
+#endif
         }
 
         [Test]
         [ExpectedException(typeof(ArgumentNullException))]
         public void TestNullActionDelegate()
         {
-            new Test(TestName, null, 1, GetTestGroup());
+#if XUNIT
+            Xunit.Assert.Throws<ArgumentNullException>(() =>
+            {
+#endif
+                new Test(TestName, null, 1, GetTestGroup());
+#if XUNIT
+            });
+#endif
         }
 
         [Test]
         [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void TestInvalidExecCount()
         {
-            new Test(TestName, DoNothingAction, 0, GetTestGroup());
+#if XUNIT
+            Xunit.Assert.Throws<ArgumentOutOfRangeException>(() => {
+#endif
+                new Test(TestName, DoNothingAction, 0, GetTestGroup());
+#if XUNIT
+            });
+#endif
         }
 
         [Test]
         [ExpectedException(typeof(ArgumentNullException))]
         public void TestNullTestGroup()
         {
-            new Test(TestName, DoNothingAction, 1, null);
-        }
+#if XUNIT
+            Xunit.Assert.Throws<ArgumentNullException>(() =>
+            {
+#endif
+                new Test(TestName, DoNothingAction, 1, null);
+#if XUNIT
+            });
+#endif
+            }
 
-        [Test]
+            [Test]
         public void TestExecuteWithNoException()
         {
             var testAction = new Test(TestName, SleepForJustOverOneSecondAction, 1, GetTestGroup());

--- a/tests/SimpleSpeedTester.Tests/TestBridge.cs
+++ b/tests/SimpleSpeedTester.Tests/TestBridge.cs
@@ -1,0 +1,42 @@
+﻿#if XUNIT
+using System;
+
+namespace SimpleSpeedTester.Tests
+{
+    public class ApplicationException : Exception { } // just doesn't exist
+}
+namespace NUnit.Framework
+{
+    public class TestFixtureAttribute : Attribute { }
+
+    public class TestAttribute : Xunit.FactAttribute { }
+
+    // note: this doesn't *work*; it requires code changes
+    public class ExpectedExceptionAttribute : Attribute {
+        public ExpectedExceptionAttribute(Type type) { }
+    }
+    static class Assert
+    {
+        public static void IsTrue(bool condition)
+        {
+            Xunit.Assert.True(condition);
+        }
+        public static void AreEqual<T>(T x, T y)
+        {
+            Xunit.Assert.Equal<T>(x, y);
+        }
+        public static void IsNull(object @object)
+        {
+            Xunit.Assert.Null(@object);
+        }
+        public static void IsNotNull(object @object)
+        {
+            Xunit.Assert.NotNull(@object);
+        }
+        public static void IsInstanceOf(Type type, object @object)
+        {
+            Xunit.Assert.IsType(type, @object);
+        }
+    }
+}
+#endif

--- a/tests/SimpleSpeedTester.Tests/TestGroupTest.cs
+++ b/tests/SimpleSpeedTester.Tests/TestGroupTest.cs
@@ -14,14 +14,28 @@ namespace SimpleSpeedTester.Tests
         [ExpectedException(typeof(ArgumentException))]
         public void TestNullTestGroupName()
         {
-            new TestGroup(null);
+#if XUNIT
+            Xunit.Assert.Throws<ArgumentException>(() =>
+            {
+#endif
+                new TestGroup(null);
+#if XUNIT
+            });
+#endif
         }
 
         [Test]
         [ExpectedException(typeof(ArgumentException))]
         public void TestEmptyTestGroupName()
         {
-            new TestGroup(string.Empty);
+#if XUNIT
+            Xunit.Assert.Throws<ArgumentException>(() =>
+            {
+#endif
+                new TestGroup(string.Empty);
+#if XUNIT
+            });
+#endif
         }
 
         [Test]

--- a/tests/SimpleSpeedTester.Tests/TestResultTest.cs
+++ b/tests/SimpleSpeedTester.Tests/TestResultTest.cs
@@ -14,14 +14,28 @@ namespace SimpleSpeedTester.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void TestNullTestAction()
         {
-            new TestResult(null, new List<TestOutcome>());
+#if XUNIT
+            Xunit.Assert.Throws<ArgumentNullException>(() =>
+            {
+#endif
+                new TestResult(null, new List<TestOutcome>());
+#if XUNIT
+            });
+#endif
         }
 
         [Test]
         [ExpectedException(typeof(ArgumentNullException))]
         public void TestNullTestActionOutcomes()
         {
-            new TestResult(GetTest(DoNothingAction, 1), null);
+#if XUNIT
+            Xunit.Assert.Throws<ArgumentNullException>(() =>
+            {
+#endif
+                new TestResult(GetTest(DoNothingAction, 1), null);
+#if XUNIT
+            });
+#endif
         }
 
         [Test]

--- a/tests/SimpleSpeedTester.Tests/project.json
+++ b/tests/SimpleSpeedTester.Tests/project.json
@@ -10,7 +10,7 @@
       "version": "1.1.1"
     },
     "xunit": "2.1.0",
-    "xunit.runner.dnx": "2.1.0-beta6-build191"
+    "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
   "frameworks": {
     "dnx451": {
@@ -18,11 +18,11 @@
     "dnxcore50": {
       "compilationOptions": { "define": [ "COREFX" ] },
       "dependencies": {
-        "System.Runtime": "4.0.21-beta-23409",
-        "System.Runtime.Extensions": "4.0.11-beta-23409",
-        "System.Collections": "4.0.11-beta-23409",
-        "System.Collections.Concurrent": "4.0.11-beta-23409",
-        "System.Linq": "4.0.1-beta-23409"
+        "System.Runtime": "4.0.21-beta-23516",
+        "System.Runtime.Extensions": "4.0.11-beta-23516",
+        "System.Collections": "4.0.11-beta-23516",
+        "System.Collections.Concurrent": "4.0.11-beta-23516",
+        "System.Linq": "4.0.1-beta-23516"
       }
     }
   }

--- a/tests/SimpleSpeedTester.Tests/project.json
+++ b/tests/SimpleSpeedTester.Tests/project.json
@@ -18,11 +18,11 @@
     "dnxcore50": {
       "compilationOptions": { "define": [ "COREFX" ] },
       "dependencies": {
-        "System.Runtime": "4.0.21-beta-23516",
-        "System.Runtime.Extensions": "4.0.11-beta-23516",
-        "System.Collections": "4.0.11-beta-23516",
-        "System.Collections.Concurrent": "4.0.11-beta-23516",
-        "System.Linq": "4.0.1-beta-23516"
+        "System.Runtime": "4.0.21-*",
+        "System.Runtime.Extensions": "4.0.11-*",
+        "System.Collections": "4.0.11-*",
+        "System.Collections.Concurrent": "4.0.11-*",
+        "System.Linq": "4.0.1-*"
       }
     }
   }

--- a/tests/SimpleSpeedTester.Tests/project.json
+++ b/tests/SimpleSpeedTester.Tests/project.json
@@ -10,7 +10,7 @@
       "version": "1.1.1"
     },
     "xunit": "2.1.0",
-    "xunit.runner.dnx": "2.1.0-rc1-build204"
+    "xunit.runner.dnx": "2.1.0-*"
   },
   "frameworks": {
     "dnx451": {

--- a/tests/SimpleSpeedTester.Tests/project.json
+++ b/tests/SimpleSpeedTester.Tests/project.json
@@ -1,0 +1,29 @@
+﻿{
+  "version": "1.0",
+  "commands": {
+    "test": "xunit.runner.dnx"
+  },
+  "compilationOptions": {"define": [ "XUNIT" ]},
+  "dependencies": {
+    "SimpleSpeedTester": {
+      "target": "project",
+      "version": "1.1.1"
+    },
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191"
+  },
+  "frameworks": {
+    "dnx451": {
+    },
+    "dnxcore50": {
+      "compilationOptions": { "define": [ "COREFX" ] },
+      "dependencies": {
+        "System.Runtime": "4.0.21-beta-23409",
+        "System.Runtime.Extensions": "4.0.11-beta-23409",
+        "System.Collections": "4.0.11-beta-23409",
+        "System.Collections.Concurrent": "4.0.11-beta-23409",
+        "System.Linq": "4.0.1-beta-23409"
+      }
+    }
+  }
+}


### PR DESCRIPTION
The main project builds for NET40, DNX451 and DNXCORE50

The test project builds for DNX451 and DNXCORE50, mainly due to switch to xunit (supported by DNX tooling; nunit isn't) - the current xunit stuff doesn't support NET40

I've left the non-DNX solution alone - the cheeky TestBridge.cs makes the tests translate without too many code changes (just the ExpectedException stuff)

Note this will need updating when DNX RTM happens
